### PR TITLE
Fixed freezing of thumb when touch ended outside of frame

### DIFF
--- a/AnimatedSegmentSwitch/AnimatedSegmentSwitch.swift
+++ b/AnimatedSegmentSwitch/AnimatedSegmentSwitch.swift
@@ -155,10 +155,8 @@ import UIKit
             thumbView.frame = frame
         } else if gesture.state == .Ended || gesture.state == .Failed || gesture.state == .Cancelled {
             let location = gesture.locationInView(self)
-            if let index = indexAtLocation(location) {
-                selectedIndex = index
-                sendActionsForControlEvents(.ValueChanged)
-            }
+            selectedIndex = nearestIndexAtLocation(location)
+            sendActionsForControlEvents(.ValueChanged)
         }
     }
 
@@ -230,7 +228,16 @@ import UIKit
         }
         return calculatedIndex
     }
-
+    
+    private func nearestIndexAtLocation(location: CGPoint) -> Int {
+        var calculatedDistances : [CGFloat] = []
+        for (index, item) in labels.enumerate() {
+            let distance = sqrt(pow(location.x - item.center.x, 2) + pow(location.y - item.center.y, 2))
+            calculatedDistances.insert(distance, atIndex: index)
+        }
+        return calculatedDistances.indexOf(calculatedDistances.minElement()!)!
+    }
+    
     private func addIndividualItemConstraints(items: [UIView], mainView: UIView, padding: CGFloat) {
         for (index, button) in items.enumerate() {
             let topConstraint = NSLayoutConstraint(item: button,


### PR DESCRIPTION
If you move your finger outside of frame while touching, then thumb will freeze. I think expected behavior should be to select the nearest item.

Interaction now:
![before](https://cloud.githubusercontent.com/assets/3402520/11683756/f3e7f738-9e7d-11e5-9f27-4d17254dfc2b.gif)
Interaction with changes from this pull request:
![after](https://cloud.githubusercontent.com/assets/3402520/11683763/fb26f792-9e7d-11e5-9567-72b0abd6a221.gif)
