### PR TITLE
Added method for setting selected index without animation

### DIFF
--- a/AnimatedSegmentSwitch/AnimatedSegmentSwitch.swift
+++ b/AnimatedSegmentSwitch/AnimatedSegmentSwitch.swift
@@ -20,12 +20,13 @@ import UIKit
         }
     }
 
-    public var selectedIndex: Int = 0 {
-        didSet {
-            displayNewSelectedIndex()
-        }
+    public private(set) var selectedIndex: Int = 0
+    
+    public func setSelectedIndex(index: Int, animated: Bool) {
+        selectedIndex = index
+        displayNewSelectedIndex(animated: animated)
     }
-
+    
     public var animationDuration: NSTimeInterval = 0.5
     public var animationSpringDamping: CGFloat = 0.6
     public var animationInitialSpringVelocity: CGFloat = 0.8
@@ -139,7 +140,7 @@ import UIKit
     override public func beginTrackingWithTouch(touch: UITouch, withEvent event: UIEvent?) -> Bool {
         let location = touch.locationInView(self)
         if let index = indexAtLocation(location) {
-            selectedIndex = index
+            setSelectedIndex(index, animated: true)
             sendActionsForControlEvents(.ValueChanged)
         }
         return false
@@ -155,7 +156,8 @@ import UIKit
             thumbView.frame = frame
         } else if gesture.state == .Ended || gesture.state == .Failed || gesture.state == .Cancelled {
             let location = gesture.locationInView(self)
-            selectedIndex = nearestIndexAtLocation(location)
+            let index = nearestIndexAtLocation(location)
+            setSelectedIndex(index, animated: true)
             sendActionsForControlEvents(.ValueChanged)
         }
     }
@@ -178,26 +180,30 @@ import UIKit
         thumbView.backgroundColor = thumbColor
         thumbView.layer.cornerRadius = (thumbCornerRadius ?? thumbView.frame.height / 2) - thumbInset
 
-        displayNewSelectedIndex()
+        displayNewSelectedIndex(animated: false)
     }
 
     // MARK: - Private - Helpers
 
-    private func displayNewSelectedIndex() {
+    private func displayNewSelectedIndex(animated animated: Bool) {
         for (_, item) in labels.enumerate() {
             item.textColor = titleColor
         }
 
         let label = labels[selectedIndex]
         label.textColor = selectedTitleColor
-
-        UIView.animateWithDuration(animationDuration,
-            delay: 0.0,
-            usingSpringWithDamping: animationSpringDamping,
-            initialSpringVelocity: animationInitialSpringVelocity,
-            options: [],
-            animations: { self.thumbView.frame = label.frame },
-            completion: nil)
+        
+        if animated {
+            UIView.animateWithDuration(animationDuration,
+                delay: 0.0,
+                usingSpringWithDamping: animationSpringDamping,
+                initialSpringVelocity: animationInitialSpringVelocity,
+                options: [],
+                animations: { self.thumbView.frame = label.frame },
+                completion: nil)
+        } else {
+            self.thumbView.frame = label.frame
+        }
     }
 
     private func setSelectedColors() {

--- a/AnimatedSegmentSwitchExample/AnimatedSegmentSwitchExample/ViewController.swift
+++ b/AnimatedSegmentSwitchExample/AnimatedSegmentSwitchExample/ViewController.swift
@@ -31,7 +31,7 @@ class ViewController: UIViewController {
         segmentControl.addTarget(self, action: "segmentValueDidChange:", forControlEvents: .ValueChanged)
         
         segmentControl.items = ["Swift", "Objective-C"]
-        segmentControl.selectedIndex = 0
+        segmentControl.setSelectedIndex(0, animated: true)
 
         return segmentControl
     }()
@@ -76,7 +76,7 @@ class ViewController: UIViewController {
         segmentControl.addTarget(self, action: "segmentValueDidChange:", forControlEvents: .ValueChanged)
 
         segmentControl.items = ["Line", "Lyft", "Plus"]
-        segmentControl.selectedIndex = 1
+        segmentControl.setSelectedIndex(1, animated: true)
 
         return segmentControl
     }()
@@ -102,7 +102,7 @@ class ViewController: UIViewController {
         segmentControl.addTarget(self, action: "segmentValueDidChange:", forControlEvents: .ValueChanged)
         
         segmentControl.items = ["No tip", "$ 1", "$ 2", "$ 5", "Other"]
-        segmentControl.selectedIndex = 3
+        segmentControl.setSelectedIndex(3, animated: true)
         
         return segmentControl
     }()


### PR DESCRIPTION
In some cases it is necessary to set selected index without animation. For example, to customize UITableViewCell after reusing, otherwise thumb will jump every time when appears on screen (as mentioned in #3)

![reusing](https://cloud.githubusercontent.com/assets/3402520/14456903/60b32f62-00b8-11e6-930d-7d053a299711.gif)
